### PR TITLE
chore(heroku): correct app.json file

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,9 +13,6 @@
     "PAPERTRAIL_API_TOKEN": {
       "required": true
     },
-    "PORT": {
-      "required": true
-    },
     "ROOT_URL": {
       "required": true
     }


### PR DESCRIPTION
#### What does this PR do?
Corrects the app.json file in project root directory, as attribute PORT is not suppose to be present.

#### Description of task completed
- Deleted the PORT attribute from app.json file


<img width="1440" alt="screen shot 2018-01-11 at 3 22 45 pm" src="https://user-images.githubusercontent.com/32123313/34830174-568e4a6c-f6e3-11e7-8492-e5bcaf8c4c66.png">
