### PR TITLE
#154015501 - Products should be arranged according to categories

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/homepage/categories.less
+++ b/imports/plugins/included/default-theme/client/styles/homepage/categories.less
@@ -23,12 +23,14 @@
     min-width:100%;
     height:230px;
 }
-.category-div .custom-overlay-top span{
+.category-div .custom-overlay-top button{
     display:block;
     text-align: center;
     font-size:25px;
     color:white;
     margin:80px auto 0;
+    background: none;
+    border: none;
 }
 
 .header {

--- a/imports/plugins/included/default-theme/client/styles/homepage/parallax.less
+++ b/imports/plugins/included/default-theme/client/styles/homepage/parallax.less
@@ -33,7 +33,7 @@
     line-height:150%;
     color:white;
 }
-.homepage-parallax-content a span{
+.homepage-parallax-content button{
     display:inline-block;
     padding:15px 20px;
     margin:20px 0 0;

--- a/imports/plugins/included/product-admin/client/components/productAdmin.js
+++ b/imports/plugins/included/product-admin/client/components/productAdmin.js
@@ -6,6 +6,8 @@ import "velocity-animate/velocity.ui";
 import { Components } from "@reactioncommerce/reaction-components";
 import { Router } from "/client/api";
 import update from "react/lib/update";
+import { ProductCategory } from "/lib/collections";
+import productCategoryList from "../../../products/productCategoryList";
 
 const fieldNames = [
   "title",
@@ -17,7 +19,8 @@ const fieldNames = [
   "facebookMsg",
   "twitterMsg",
   "pinterestMsg",
-  "googleplusMsg"
+  "googleplusMsg",
+  "productCategory"
 ];
 
 const fieldGroups = {
@@ -218,7 +221,18 @@ class ProductAdmin extends Component {
     return this.state.expandedCard === groupName;
   }
 
+  productCatgoryFunction() {
+    return productCategoryList.map(category => {
+      ProductCategory.insert({
+        title: category.title,
+        isDigital: category.isDigital
+      });
+    });
+  }
+
   render() {
+    console.log("\n template", this.props.templates, "\n categories", productCategoryList);
+    console.log("\n productTemplate", this.product.template);
     return (
       <Components.CardGroup>
         <Components.Card
@@ -316,6 +330,18 @@ class ProductAdmin extends Component {
               ref="countryOfOriginInput"
               value={this.product.originCountry}
               options={this.props.countries}
+            />
+            <Components.Select
+              clearable={false}
+              i18nKeyLabel="productDetailEdit.productCategory"
+              i18nKeyPlaceholder="productDetailEdit.productCategory"
+              label="Product Category"
+              name="productCategory"
+              onChange={this.handleSelectChange}
+              placeholder="Select a Category"
+              ref="productCategoryInput"
+              value={this.product.productCategory}
+              options={productCategoryList}
             />
           </Components.CardBody>
         </Components.Card>
@@ -425,6 +451,7 @@ class ProductAdmin extends Component {
 }
 
 ProductAdmin.propTypes = {
+  categories: PropTypes.arrayOf(PropTypes.object),
   countries: PropTypes.arrayOf(PropTypes.object),
   editFocus: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   editable: PropTypes.bool,

--- a/imports/plugins/included/products/productCategoryList.js
+++ b/imports/plugins/included/products/productCategoryList.js
@@ -1,0 +1,47 @@
+export const productCategoryList =
+[
+  {
+    _id: 1,
+    label: "Fashion",
+    value: "Fashion",
+    isDigital: false
+  },
+  {
+    _id: 2,
+    label: "Phones and Tablets",
+    value: "Phones and Tablets",
+    isDigital: false
+  },
+  {
+    _id: 3,
+    label: "Groceries and Fresh Foods",
+    value: "Groceries and Fresh Foods",
+    isDigital: false
+  },
+  {
+    _id: 4,
+    label: "Digital Products",
+    value: "Digital Products",
+    isDigital: false
+  },
+  {
+    _id: 5,
+    label: "Computing",
+    value: "Computing",
+    isDigital: true
+  },
+  {
+    _id: 6,
+    label: "Games and Accessories",
+    value: "Games and Accessories",
+    isDigital: true
+  },
+  {
+    _id: 7,
+    label: "Office Tools",
+    value: "Office Tools",
+    isDigital: false
+  }
+];
+
+export default productCategoryList;

--- a/imports/plugins/included/ui-homepage/client/components/productCategories.js
+++ b/imports/plugins/included/ui-homepage/client/components/productCategories.js
@@ -1,0 +1,151 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Components } from "@reactioncommerce/reaction-components";
+import { Reaction } from "/client/api";
+import { getTagIds as getIds } from "/lib/selectors/tags";
+
+/** Class representing the Products React component
+ * @summary PropTypes for Product React component
+ * @property {Function} loadMoreProducts - load more products callback
+ * @property {Function} loadProducts - Load products callback
+ * @property {Array} products - Array of products
+ * @property {Object} products - Products subscription
+ * @property {Function} ready - Ready state check helper
+ * @property {Boolean} showNotFound - Force show not-found view
+*/
+
+class ProductCategories extends Component {
+  static propTypes = {
+    loadMoreProducts: PropTypes.func,
+    loadProducts: PropTypes.func,
+    products: PropTypes.array,
+    productsSubscription: PropTypes.object,
+    ready: PropTypes.func,
+    showNotFound: PropTypes.bool
+  };
+
+  /**
+   * Checks and returns a Boolean if the `products` array from props is not empty.
+   * @return {Boolean} Boolean value `true` if products are available, `false` otherwise.
+   */
+  get hasProducts() {
+    return Array.isArray(this.props.products) && this.props.products.length > 0;
+  }
+
+  /**
+   * Handle load more button click
+   * @access protected
+   * @param  {SyntheticEvent} event Synthetic event object
+   * @return {undefined}
+   */
+  handleClick = (event) => {
+    if (this.props.loadProducts) {
+      this.props.loadProducts(event);
+    }
+  }
+
+  /**
+   * Render product grid
+   * @access protected
+   * @return {Node} React node containing the `ProductGrid` component.
+   */
+  renderProductGrid() {
+    const products = this.props.products;
+
+    const productsByKey = {};
+
+    if (Array.isArray(products)) {
+      for (const product of products) {
+        productsByKey[product._id] = product;
+      }
+    }
+
+    return (
+      <Components.ProductGrid
+        productsByKey={productsByKey || {}}
+        productIds={getIds({ tags: products })}
+        canEdit={Reaction.hasPermission("createProduct")}
+        products={products}
+      />
+    );
+  }
+
+  /**
+   * Render loading component
+   * @access protected
+   * @return {Node} React node containing the `Loading` component.
+   */
+  renderSpinner() {
+    if (this.props.productsSubscription.ready() === false) {
+      return (
+        <Components.Loading />
+      );
+    }
+  }
+
+  /**
+   * Render load more button
+   * @access protected
+   * @return {Node|undefined} React node contianing a `laod more` button or undefined.
+   */
+  renderLoadMoreProductsButton() {
+    if (this.props.loadMoreProducts()) {
+      return (
+        <div className="product-load-more" id="productScrollLimitLoader">
+          <button
+            className="btn btn-inverse btn-block btn-lg"
+            onClick={this.handleClick}
+          >
+            <Components.Translation defaultValue="Load more products" i18nKey="app.loadMoreProducts" />
+          </button>
+        </div>
+      );
+    }
+  }
+
+  /**
+   * Render the not found component
+   * @access protected
+   * @return {Node} React node contianing the `NotFound` component.
+   */
+  renderNotFound() {
+    return (
+      <Components.NotFound
+        i18nKeyTitle="productGrid.noProductsFound"
+        icon="fa fa-barcode"
+        title="No Products Found"
+      />
+    );
+  }
+
+  /**
+   * Render component
+   * @access protected
+   * @return {Node} React node containing elements that make up the `Products` component.
+   */
+  render() {
+    // Force show the not-found view.
+    if (this.props.showNotFound) {
+      return this.renderNotFound();
+    } else if (this.props.ready()) {
+      // Render products grid if products are available after subscription ready.
+      if (this.hasProducts) {
+        return (
+          <div id="container-main">
+            {this.renderProductGrid()}
+            {this.renderLoadMoreProductsButton()}
+            {this.renderSpinner()}
+          </div>
+        );
+      }
+
+      // Render not-found view if no products are available.
+      return this.renderNotFound();
+    }
+
+    // Render loading component by default if no condition above matches.
+    return this.renderSpinner();
+  }
+}
+
+export default ProductCategories;

--- a/imports/plugins/included/ui-homepage/client/containers/productCategoriesContainer.js
+++ b/imports/plugins/included/ui-homepage/client/containers/productCategoriesContainer.js
@@ -1,0 +1,217 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { compose } from "recompose";
+import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
+import { Meteor } from "meteor/meteor";
+import { Session } from "meteor/session";
+import { Reaction } from "/client/api";
+import { ITEMS_INCREMENT } from "/client/config/defaults";
+import { ReactionProduct } from "/lib/api";
+import { applyProductRevision } from "/lib/api/products";
+import { Products, Tags, Shops } from "/lib/collections";
+import ProductCategoriesComponent from "../components/productCategories";
+
+/**
+ * loadMoreProducts
+ * @summary whenever #productScrollLimitLoader becomes visible, retrieve more results
+ * this basically runs this:
+ * Session.set('productScrollLimit', Session.get('productScrollLimit') + ITEMS_INCREMENT);
+ * @return {undefined}
+ */
+function loadMoreProducts() {
+  let threshold;
+  const target = document.querySelectorAll("#productScrollLimitLoader");
+  let scrollContainer = document.querySelectorAll("#container-main");
+  if (scrollContainer.length === 0) {
+    scrollContainer = window;
+  }
+
+  if (target.length) {
+    threshold = scrollContainer[0].scrollHeight - scrollContainer[0].scrollTop === scrollContainer[0].clientHeight;
+
+    if (threshold) {
+      if (!target[0].getAttribute("visible")) {
+        target[0].setAttribute("productScrollLimit", true);
+        Session.set("productScrollLimit", Session.get("productScrollLimit") + ITEMS_INCREMENT || 24);
+      }
+    } else {
+      if (target[0].getAttribute("visible")) {
+        target[0].setAttribute("visible", false);
+      }
+    }
+  }
+}
+
+const wrapComponent = (Comp) => (
+  class ProductsContainer extends Component {
+    static propTypes = {
+      canLoadMoreProducts: PropTypes.bool,
+      products: PropTypes.array,
+      productsSubscription: PropTypes.object,
+      showNotFound: PropTypes.bool
+    };
+
+    constructor(props) {
+      super(props);
+      this.state = {
+        initialLoad: true
+      };
+
+      this.ready = this.ready.bind(this);
+      this.loadMoreProducts = this.loadMoreProducts.bind(this);
+    }
+
+    ready = () => {
+      if (this.props.showNotFound === true) {
+        return false;
+      }
+
+      const isInitialLoad = this.state.initialLoad === true;
+      const isReady = this.props.productsSubscription.ready();
+
+      if (isInitialLoad === false) {
+        return true;
+      }
+
+      if (isReady) {
+        return true;
+      }
+
+      return false;
+    }
+
+    loadMoreProducts = () => {
+      return this.props.canLoadMoreProducts === true;
+    }
+
+    loadProducts = (event) => {
+      event.preventDefault();
+      this.setState({
+        initialLoad: false
+      });
+      loadMoreProducts();
+    }
+
+    render() {
+      return (
+        <Comp
+          ready={this.ready}
+          products={this.props.products}
+          productsSubscription={this.props.productsSubscription}
+          loadMoreProducts={this.loadMoreProducts}
+          loadProducts={this.loadProducts}
+          showNotFound={this.props.showNotFound}
+        />
+      );
+    }
+  }
+);
+
+function composer(props, onData) {
+  window.prerenderReady = false;
+
+  let canLoadMoreProducts = false;
+
+  const slug = Reaction.Router.getParam("slug");
+  const shopIdOrSlug = Reaction.Router.getParam("shopSlug");
+
+  const tag = Tags.findOne({ slug }) || Tags.findOne(slug);
+  const scrollLimit = Session.get("productScrollLimit");
+  let tags = {}; // this could be shop default implementation needed
+  let shopIds = {};
+
+  if (tag) {
+    tags = { tags: [tag._id] };
+  }
+
+  if (shopIdOrSlug) {
+    shopIds = { shops: [shopIdOrSlug] };
+  }
+
+  // if we get an invalid slug, don't return all products
+  if (!tag && slug) {
+    onData(null, {
+      showNotFound: true
+    });
+
+    return;
+  }
+
+  const currentTag = ReactionProduct.getTag();
+
+  const sort = {
+    [`positions.${currentTag}.position`]: 1,
+    [`positions.${currentTag}.createdAt`]: 1,
+    createdAt: 1
+  };
+
+  // Get the current user and their preferences
+  const user = Meteor.user();
+  const prefs = user && user.profile && user.profile.preferences;
+
+  // Edit mode is true by default
+  let editMode = true;
+
+  // if we have a "viewAs" preference and the preference is not set to "administrator", then edit mode is false
+  if (prefs && prefs["reaction-dashboard"] && prefs["reaction-dashboard"].viewAs) {
+    if (prefs["reaction-dashboard"].viewAs !== "administrator") {
+      editMode = false;
+    }
+  }
+
+  const queryParams = Object.assign({}, tags, Reaction.Router.current().queryParams, shopIds);
+  const productsSubscription = Meteor.subscribe("Products", scrollLimit, queryParams, sort, editMode);
+
+  if (productsSubscription.ready()) {
+    window.prerenderReady = true;
+  }
+
+  const activeShopsIds = Shops.find({
+    $or: [
+      { "workflow.status": "active" },
+      { _id: Reaction.getPrimaryShopId() }
+    ]
+  }).fetch().map(activeShop => activeShop._id);
+
+  const category = localStorage.getItem("category");
+
+  const productCursor = Products.find({
+    ancestors: [],
+    type: { $in: ["simple"] },
+    shopId: { $in: activeShopsIds },
+    productCategory: category
+  });
+
+  const products = productCursor.map((product) => {
+    return applyProductRevision(product);
+  });
+
+  const sortedProducts = ReactionProduct.sortProducts(products, currentTag);
+
+
+  canLoadMoreProducts = productCursor.count() >= Session.get("productScrollLimit");
+  const stateProducts = sortedProducts;
+
+  Session.set("productGrid/products", sortedProducts);
+
+  const isActionViewOpen = Reaction.isActionViewOpen();
+  if (isActionViewOpen === false) {
+    Session.set("productGrid/selectedProducts", []);
+  }
+
+  onData(null, {
+    productsSubscription,
+    products: stateProducts,
+    canLoadMoreProducts
+  });
+}
+
+registerComponent("ProductCategories", ProductCategoriesComponent, [
+  composeWithTracker(composer),
+  wrapComponent
+]);
+
+export default compose(
+  composeWithTracker(composer),
+  wrapComponent
+)(ProductCategoriesComponent);

--- a/imports/plugins/included/ui-homepage/client/index.js
+++ b/imports/plugins/included/ui-homepage/client/index.js
@@ -2,3 +2,9 @@ import "./templates/carousel.html";
 import "./templates/men.html";
 import "./templates/categories.html";
 import "./templates/digitals.html";
+import "./templates/categories.js";
+import "./templates/productCategory.html";
+import "./templates/productCategory.js";
+
+export { default as ProductCategories } from "./components/productCategories";
+export { default as ProductCategoriesContainer } from "./containers/productCategoriesContainer";

--- a/imports/plugins/included/ui-homepage/client/templates/categories.html
+++ b/imports/plugins/included/ui-homepage/client/templates/categories.html
@@ -5,20 +5,26 @@
             <div class="row mt-4">
                 <!-- A category -->
                 <div class="col-md-4">
-                    <div class="category-div">
-                        <div class="custom-overlay"></div>
-                        <div class="custom-overlay-top">
-                            <span>Fashion</span>
+                    
+                        <div class="category-div">
+                            <div class="custom-overlay"></div>
+                            <div class="custom-overlay-top">
+                                <span>
+                                    <button value="Fashion">Fashion</button>
+                                </span>
+                            </div>
+                            <img src="/resources/images/homepage/fashion.jpg">
                         </div>
-                        <img src="/resources/images/homepage/fashion.jpg">
-                    </div>
+                    
                 </div>
                 <!-- A category -->
                 <div class="col-md-4">
                     <div class="category-div">
                         <div class="custom-overlay"></div>
                         <div class="custom-overlay-top">
-                            <span>Phones and Tablets</span>
+                            <span>
+                                <button value="Phones and Tablets">Phones and Tablets</button>
+                            </span>
                         </div>
                         <img src="/resources/images/homepage/mobile.jpg">
                     </div>
@@ -28,7 +34,9 @@
                     <div class="category-div">
                         <div class="custom-overlay"></div>
                         <div class="custom-overlay-top">
-                            <span>Groceries</span>
+                            <span>
+                                <button value="Groceries and Fresh Foods">Groceries and Fresh Foods</button>
+                            </span>
                         </div>
                         <img src="/resources/images/homepage/groceries.jpg">
                     </div>
@@ -38,7 +46,9 @@
                     <div class="category-div">
                         <div class="custom-overlay"></div>
                         <div class="custom-overlay-top">
-                            <span>Computing</span>
+                            <span>
+                                <button value="Computing">Computing</button>
+                            </span>
                         </div>
                         <img src="/resources/images/homepage/computer.jpg">
                     </div>
@@ -48,7 +58,7 @@
                     <div class="category-div">
                         <div class="custom-overlay"></div>
                         <div class="custom-overlay-top">
-                            <span>Game and Consoles</span>
+                            <button value="Games and Accessories">Games and Accessories</button>
                         </div>
                         <img src="/resources/images/homepage/gaming.jpg">
                     </div>
@@ -58,7 +68,9 @@
                     <div class="category-div">
                         <div class="custom-overlay"></div>
                         <div class="custom-overlay-top">
-                            <span>Office Tools</span>
+                            <span>
+                                <button value="Office Tools">Office Tools</button>
+                            </span>
                         </div>
                         <img src="/resources/images/homepage/corporate.jpg">
                     </div>

--- a/imports/plugins/included/ui-homepage/client/templates/categories.js
+++ b/imports/plugins/included/ui-homepage/client/templates/categories.js
@@ -1,0 +1,18 @@
+import { Template } from "meteor/templating";
+import { Reaction } from "/client/api";
+
+Template.homepageCategories.events({
+  "click button": function (event) {
+    event.preventDefault();
+    localStorage.setItem("category", event.target.value);
+    Reaction.Router.go("category");
+  }
+});
+
+Template.homepageDigitalParallax.events({
+  "click button": function (event) {
+    event.preventDefault();
+    localStorage.setItem("category", event.target.value);
+    Reaction.Router.go("category");
+  }
+});

--- a/imports/plugins/included/ui-homepage/client/templates/digitals.html
+++ b/imports/plugins/included/ui-homepage/client/templates/digitals.html
@@ -7,9 +7,7 @@
                     <p>
                         Checkout our latest collection of digital products.
                     </p>
-                    <a href="">
-                        <span>Start Shopping</span>
-                    </a>
+                    <button value="Digital Products">Start Shopping</button>
                 </div>
             </div>
         </div>

--- a/imports/plugins/included/ui-homepage/client/templates/productCategory.html
+++ b/imports/plugins/included/ui-homepage/client/templates/productCategory.html
@@ -1,0 +1,5 @@
+<template name="productCategory">
+  <div class="row">
+    {{> React component=productComponent}}
+  </div>
+</template>

--- a/imports/plugins/included/ui-homepage/client/templates/productCategory.js
+++ b/imports/plugins/included/ui-homepage/client/templates/productCategory.js
@@ -1,0 +1,8 @@
+import { Components } from "@reactioncommerce/reaction-components";
+import { Template } from "meteor/templating";
+
+Template.productCategory.helpers({
+  productComponent() {
+    return Components.ProductCategories;
+  }
+});

--- a/imports/plugins/included/ui-homepage/register.js
+++ b/imports/plugins/included/ui-homepage/register.js
@@ -1,0 +1,15 @@
+import { Reaction } from "/server/api";
+
+Reaction.registerPackage({
+  label: "category",
+  name: "category",
+  autoEnable: true,
+  registry: [{
+    route: "category",
+    name: "category",
+    label: "Category",
+    template: "productCategory",
+    workflow: "coreProductWorkflow"
+  }],
+  layout: []
+});

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -3,6 +3,7 @@ import { Mongo } from "meteor/mongo";
 import { Meteor } from "meteor/meteor";
 import * as Schemas from "./schemas";
 import { cartOrderTransform } from "./transform/cartOrder";
+// import { productCategoryList } from "../../imports/plugins/included/products/productCategoryList";
 
 /**
  *
@@ -210,3 +211,10 @@ StaticPage.attachSchema(Schemas.StaticPage);
 export const Ratings = new Mongo.Collection("Ratings");
 
 Ratings.attachSchema(Schemas.Ratings);
+
+/**
+ * Categories collection
+ */
+
+export const ProductCategory = new Mongo.Collection("ProductCategory");
+ProductCategory.attachSchema(Schemas.ProductCategory);

--- a/lib/collections/schemas/index.js
+++ b/lib/collections/schemas/index.js
@@ -28,3 +28,4 @@ export * from "./workflow";
 export * from "./ratings";
 export * from "./walletHistories";
 export * from "./wallets";
+export * from "./productCategory";

--- a/lib/collections/schemas/productCategory.js
+++ b/lib/collections/schemas/productCategory.js
@@ -1,0 +1,22 @@
+import { SimpleSchema } from "meteor/aldeed:simple-schema";
+import { registerSchema } from "@reactioncommerce/reaction-collections";
+
+
+export const ProductCategory = new SimpleSchema({
+  _id: {
+    type: String,
+    label: "ProductCategory Id"
+  },
+  title: {
+    type: String,
+    defaultValue: "",
+    label: "ProductCategory Title"
+  },
+  isDigital: {
+    type: Boolean,
+    defaultValue: false,
+    label: "isDigital"
+  }
+});
+registerSchema("ProductCategory", ProductCategory);
+export default ProductCategory;

--- a/lib/collections/schemas/products.js
+++ b/lib/collections/schemas/products.js
@@ -329,6 +329,18 @@ export const ProductVariant = new SimpleSchema({
     type: String,
     defaultValue: ""
   },
+  productTitle: {
+    type: String,
+    optional: true,
+    defaultValue: "nonDigital",
+    label: "Product Type"
+  },
+  productCategory: {
+    type: String,
+    defaultValue: "General",
+    optional: true,
+    label: "Product Category"
+  },
   optionTitle: {
     label: "Option",
     type: String,
@@ -467,7 +479,15 @@ export const Product = new SimpleSchema({
   },
   productType: {
     type: String,
-    optional: true
+    optional: true,
+    defaultValue: "nonDigital",
+    label: "Product Type"
+  },
+  productCategory: {
+    type: String,
+    defaultValue: "General",
+    optional: true,
+    label: "Product Category"
   },
   originCountry: {
     type: String,

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -66,8 +66,9 @@ export default {
     const registeredPackage = (this.Packages[packageInfo.name] = packageInfo);
     return registeredPackage;
   },
-  defaultCustomerRoles: ["guest", "account/profile", "product", "tag", "index", "cart/checkout", "cart/completed", "staticPageView", "wallet", "account/wallet"],
-  defaultVisitorRoles: ["anonymous", "guest", "product", "tag", "index", "cart/checkout", "cart/completed", "staticPageView"],
+  defaultCustomerRoles: [
+    "guest", "account/profile", "product", "tag", "index", "cart/checkout", "cart/completed", "staticPageView", "wallet", "account/wallet"],
+  defaultVisitorRoles: ["anonymous", "guest", "product", "tag", "index", "cart/checkout", "cart/completed", "staticPageView", "category"],
   createGroups,
   /**
    * canInviteToGroup

--- a/server/methods/getProductCategory.js
+++ b/server/methods/getProductCategory.js
@@ -1,0 +1,6 @@
+import { Meteor } from "meteor/meteor";
+import * as Collections from "/lib/collections";
+
+Meteor.methods({
+  productCategory: () =>  Collections.ProductCategory.find().fetch()
+});


### PR DESCRIPTION
 #### What does this PR do?

- Similar products should be grouped under the same category

 #### Description of Task to be completed?

- When a user visits the homepage, the user should see a section containing various categories of products available on the site, when clicked the user should be redirected to a page where they see products in that category.

 #### How should this be manually tested?

- Clone the repo - `$ git clone https://github.com/andela/k2-rc.git`
- Follow the project README to set up the application on your machine
- Go to the project homepage
- Navigate to the `categories` section
- Click on any of the available categories to go to the page containing all the products in that category
- Click on `START SHOPPING` button in the `Digital products` section at the bottom of the page to go to a page containing digital products

#### What are the relevant pivotal tracker stories?

- story type: feature
- story id: 154015501
- story title: Products should be arranged according to categories

 ####Any background context you want to provide?

N/A

Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-01-29 at 8 37 08 pm" src="https://user-images.githubusercontent.com/22713293/35532110-59da464e-0539-11e8-9787-eefffc3390ce.png">
<img width="1428" alt="screen shot 2018-01-29 at 6 44 12 pm" src="https://user-images.githubusercontent.com/22713293/35532111-5a01d7e0-0539-11e8-9ab3-a54da1757bfe.png">
<img width="1433" alt="screen shot 2018-01-29 at 6 43 50 pm" src="https://user-images.githubusercontent.com/22713293/35532113-5a29906e-0539-11e8-9cd6-bd25058f163c.png">


